### PR TITLE
利用するモデルをgpt-3.5-turboに変更

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,16 @@
 import os
-from flask import Flask, request, jsonify
+import json
+import requests
+from flask import Flask, request
 from slack_bolt import App
 from slack_bolt.adapter.flask import SlackRequestHandler
-import openai
 
 # 環境変数の読み込み
 bot_token = os.environ["SLACK_BOT_TOKEN"]
 slack_signing_secret = os.environ["SLACK_SIGNING_SECRET"]
-openai.api_key = os.environ["OPENAI_API_KEY"]
+openai_api_key = os.environ["OPENAI_API_KEY"]
+
+API_ENDPOINT = 'https://api.openai.com/v1/chat/completions'
 
 # Flaskアプリケーションの設定
 app = Flask(__name__)
@@ -18,17 +21,26 @@ handler = SlackRequestHandler(slack_app)
 @slack_app.event("app_mention")
 def command_handler(body, say):
     text = body["event"]["text"]
+
     # ChatGPTによる応答の生成
-    response = openai.Completion.create(
-        engine="text-davinci-002",
-        prompt=f"{text}",
-        max_tokens=50,
-        n=1,
-        stop=None,
-        temperature=0.5,
-    )
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {openai_api_key}"
+    }
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "system", "content": "You are a helpful assistant."},
+                     {"role": "user", "content": f"{text}"}],
+        "max_tokens": 2048,
+        "n": 1,
+        "stop": None,
+        "temperature": 0.5,
+    }
+    response = requests.post(API_ENDPOINT, headers=headers, data=json.dumps(data))
+    response = response.json()
+
     # Slackに返答を送信
-    reply = response.choices[0].text.strip()
+    reply = response["choices"][0]["message"]["content"].strip()
     say(reply)
 
 # Slackイベントのエンドポイント


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/chat-gpt-slack-bot/issues/5

# 内容
表題の通り。なぜか `opneai` のライブラリだと上手く動作しなかったので一旦直接リクエストを送る形で作成。