### PR TITLE
LinterとFormatterの導入

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = venv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: lint format
+
+lint:
+	flake8 .
+
+format:
+	black .

--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 from langchain import PromptTemplate, LLMChain
 from langchain.llms import OpenAIChat
 from langchain.chains.conversation.memory import ConversationBufferWindowMemory
-
-# 環境変数にAPIキーを設定
+from flask import Flask, request
+from slack_bolt import App
+from slack_bolt.adapter.flask import SlackRequestHandler
 import os
 
 OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
@@ -31,10 +32,6 @@ def create_conversational_chain():
 
 SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
 SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
-
-from flask import Flask, request
-from slack_bolt import App
-from slack_bolt.adapter.flask import SlackRequestHandler
 
 # Flaskアプリケーションの設定
 app = Flask(__name__)

--- a/app.py
+++ b/app.py
@@ -4,7 +4,9 @@ from langchain.chains.conversation.memory import ConversationBufferWindowMemory
 
 # 環境変数にAPIキーを設定
 import os
+
 OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+
 
 def create_conversational_chain():
     llm = OpenAIChat(model_name="gpt-3.5-turbo", openai_api_key=OPENAI_API_KEY)
@@ -26,6 +28,7 @@ def create_conversational_chain():
 
     return llm_chain
 
+
 SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
 SLACK_SIGNING_SECRET = os.environ["SLACK_SIGNING_SECRET"]
 
@@ -40,6 +43,7 @@ slack_request_handler = SlackRequestHandler(slack_app)
 
 chain = create_conversational_chain()
 
+
 # メッセージイベントのリスナーを設定
 @slack_app.event("app_mention")
 def command_handler(body, say):
@@ -49,10 +53,12 @@ def command_handler(body, say):
     # Slackに返答を送信
     say(text=chain.predict(input=text), thread_ts=thread_ts)
 
+
 # Slackイベントのエンドポイント
 @app.route("/slack/events", methods=["POST"])
 def slack_events():
     return slack_request_handler.handle(request)
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+exclude = 'venv'


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/chat-gpt-slack-bot/issues/7

# 内容
ChatGPTに聞いたり、調べてみたりしたが割と色々なツールがあってどれが一強というのはなさそう。

https://zenn.dev/naiq112/articles/df1b32fc08d383

Linterは [flake8](https://github.com/PyCQA/flake8)、Formatterは [black](https://github.com/psf/black) を利用する事にした。

PythonのプロジェクトではタスクランナーにMakefileを採用している事が多いのでMakefileも追加。