### PR TITLE
JSONでLLMのレスポンスを返すAPIを実装

### DIFF
--- a/app.py
+++ b/app.py
@@ -137,7 +137,20 @@ def cats_messages(cat_id):
 
     message = body["message"]
 
-    llm_response = chain.predict(input=message)
+    try:
+        llm_response = chain.predict(input=message)
+    except Exception as e:
+        app.logger.error(e)
+        error_message = f"An error occurred: {str(e)}"
+        response_body = {
+            "type": "INTERNAL_SERVER_ERROR",
+            "title": "an unexpected error has occurred.",
+            "detail": error_message,
+        }
+        json_body = json.dumps(response_body, ensure_ascii=False)
+        return Response(
+            json_body, content_type="application/json; charset=utf-8", status=500
+        )
 
     response_body = {
         "message": llm_response,


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/chat-gpt-slack-bot/issues/24

# 内容

以下のようにJSONでLLMの応答を返すエンドポイントを実装。

## サンプルリクエスト

```
curl -v \
-X POST \
-H "Content-Type: application/json" \
-H "Authorization: Basic {クレデンシャルを指定} \
-d '{
  "message": "こんにちは。もこちゃん🐱。もこちゃんが生まれてから今の飼い主さんに出会うまでの物語を教えて！"
}' \
http://localhost:5002/cats/moko/messages | jq
```

## サンプルレスポンス（正常系）

```
< HTTP/1.1 201 CREATED
< Server: Werkzeug/2.2.3 Python/3.11.3
< Date: Wed, 03 May 2023 10:15:23 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 111
< Connection: close
<
{ [111 bytes data]
100   167  100   111  100    56     34     17  0:00:03  0:00:03 --:--:--    51
* Closing connection 0
{
  "message": "にゃーん😺こんにちは！もこだにゃん🐱何かお話しにゃいかにゃ？🐾"
}
```
# サンプルレスポンス（異常系）

```
< HTTP/1.1 401 UNAUTHORIZED
< Server: Werkzeug/2.2.3 Python/3.11.3
< Date: Wed, 03 May 2023 10:17:25 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 66
< Connection: close
<
{ [66 bytes data]
100   224  100    66  100   158  13168  31524 --:--:-- --:--:-- --:--:--  218k
* Closing connection 0
{
  "type": "UNAUTHORIZED",
  "title": "invalid Authorization Header."
}
```