### PR TITLE
LinterとFormatterのルールが競合しているので解消

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,4 @@
 [flake8]
 exclude = .venv
+max-line-length = 88
+extend-ignore = E203


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/chat-gpt-slack-bot/issues/19

# 内容

`black` と `flake8`のルール競合を回避する為の設定を追加。
